### PR TITLE
export RSAKey function

### DIFF
--- a/jsbn.js
+++ b/jsbn.js
@@ -1762,10 +1762,12 @@ if (typeof exports !== 'undefined') {
   exports = module.exports = {
       default: BigInteger,
       BigInteger: BigInteger,
+      RSAKey: RSAKey,
   };
 } else {
   this.jsbn = {
     BigInteger: BigInteger,
+    RSAKey: RSAKey,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsbn-rsa",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Js biginteger and rsa implementation",
   "main": "jsbn.js",
   "types": "jsbn.d.ts",


### PR DESCRIPTION
I want to use like this
```js
const NodeRSA = require("node-rsa");
const Crypt = require("jsbn-rsa");

const nodeKey = new NodeRSA({ b: 512 });
const publicComponents = nodeKey.exportKey("components-public");
const keySample = {
  publicN: publicComponents.n.toString("hex"),
  publicE: publicComponents.e.toString(16)
};

const myKey = new Crypt.RSAKey();
myKey.setPublic(keySample.publicN, keySample.publicE);

const encrypted = myKey.encrypt("maisy");
console.log(encrypted);
```