### PR TITLE
Expose ZERO and ONE constants

### DIFF
--- a/jsbn.d.ts
+++ b/jsbn.d.ts
@@ -1,5 +1,8 @@
 
 export class BigInteger {
+    static ZERO: BigInteger;
+    static ONE: BigInteger;
+
     bitLength(): number;
     clone(): BigInteger;
     divide(n: BigInteger): BigInteger;


### PR DESCRIPTION
Expose numeric constants in the interface to enable computations such as (1<<10).